### PR TITLE
Make inventory file happy

### DIFF
--- a/inventory/cakephp-example/hosts
+++ b/inventory/cakephp-example/hosts
@@ -1,1 +1,2 @@
+[seed-hosts]
 localhost


### PR DESCRIPTION
Should fix the following warning:
```
ansible-playbook -i cakephp-example ../../casl-ansible/playbooks/openshift-cluster-seed.yml --connection=local  
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks' 
for dynamic inclusions. This feature will be removed in a future release. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: include is kept for backwards compatibility but usage is discouraged. The module documentation details page may 
explain more about this rationale.. This feature will be removed in a future release. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
 [WARNING]: Could not match supplied host pattern, ignoring: seed-hosts


PLAY [seed-hosts[0]] *******************************************************************************************************************
skipping: no hosts matched

PLAY RECAP *****************************************************************************************************************************
```