### PR TITLE
Match cakephp pod label to service selector

### DIFF
--- a/files/cakephp/deployment/template.yml
+++ b/files/cakephp/deployment/template.yml
@@ -48,7 +48,7 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      app: ${NAME}
+      application: ${NAME}
     name: ${NAME}
     namespace: ${NAMESPACE}
   spec:
@@ -67,7 +67,7 @@ objects:
     template:
       metadata:
         labels:
-          app: ${NAME}
+          application: ${NAME}
           deploymentconfig: ${NAME}
       spec:
         containers:


### PR DESCRIPTION
This will make the cakephp pod match the selector for `svc/cakephp`
<pre>
oc describe svc cakephp
Name:			cakephp
Namespace:		cakephp-dev
Labels:			application=cakephp
Annotations:		kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"labels":{"application":"cakephp"},"name":"cakephp","namespace":"cakephp-dev"},"spec":...
Selector:		<b>application=cakephp</b>,deploymentconfig=cakephp
Type:			ClusterIP
IP:			172.30.162.128
Port:			8080-tcp	8080/TCP
Endpoints:		172.17.0.3:8080
Session Affinity:	None
Events:			<none>
</pre>